### PR TITLE
fix: Tolerate destroyed vault-enterprise-deploy outputs

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,8 @@
 extends: relaxed
 
+ignore-from-file:
+  - .gitignore
+
 rules:
   comments:
     level: error

--- a/variable_sets.tf
+++ b/variable_sets.tf
@@ -119,7 +119,7 @@ resource "tfe_variable" "tfc_vault_provider_auth" {
 
 resource "tfe_variable" "tfc_vault_addr" {
   key             = "TFC_VAULT_ADDR"
-  value           = data.tfe_outputs.vault_enterprise_deploy.values.hcp_terraform_vault_addr
+  value           = try(data.tfe_outputs.vault_enterprise_deploy.values.hcp_terraform_vault_addr, "")
   category        = "env"
   description     = "The address of the Vault instance."
   variable_set_id = tfe_variable_set.vault_enterprise_authentication.id
@@ -127,7 +127,7 @@ resource "tfe_variable" "tfc_vault_addr" {
 
 resource "tfe_variable" "tfc_vault_auth_path" {
   key             = "TFC_VAULT_AUTH_PATH"
-  value           = data.tfe_outputs.vault_enterprise_deploy.values.hcp_terraform_vault_auth_path
+  value           = try(data.tfe_outputs.vault_enterprise_deploy.values.hcp_terraform_vault_auth_path, "")
   category        = "env"
   description     = "The path of the JWT auth backend in Vault."
   variable_set_id = tfe_variable_set.vault_enterprise_authentication.id
@@ -135,7 +135,7 @@ resource "tfe_variable" "tfc_vault_auth_path" {
 
 resource "tfe_variable" "tfc_vault_run_role" {
   key             = "TFC_VAULT_RUN_ROLE"
-  value           = data.tfe_outputs.vault_enterprise_deploy.values.hcp_terraform_vault_auth_run_role
+  value           = try(data.tfe_outputs.vault_enterprise_deploy.values.hcp_terraform_vault_auth_run_role, "")
   category        = "env"
   description     = "The Vault role to authenticate as via JWT."
   variable_set_id = tfe_variable_set.vault_enterprise_authentication.id
@@ -143,7 +143,7 @@ resource "tfe_variable" "tfc_vault_run_role" {
 
 resource "tfe_variable" "tfc_vault_encoded_cacert" {
   key             = "TFC_VAULT_ENCODED_CACERT"
-  value           = data.tfe_outputs.vault_enterprise_deploy.values.hcp_terraform_vault_encoded_cacert
+  value           = try(data.tfe_outputs.vault_enterprise_deploy.values.hcp_terraform_vault_encoded_cacert, "")
   category        = "env"
   description     = "A PEM-encoded CA certificate that has been Base64 encoded."
   variable_set_id = tfe_variable_set.vault_enterprise_authentication.id


### PR DESCRIPTION
- Wraps the four Vault auth variable references in `try(..., "")` so a missing output no longer fails the `hcp-terraform-admin` plan
- Fixes plan failures after the lab's Vault infra is destroyed, which empties the `vault-enterprise-deploy` workspace outputs and broke the direct `data.tfe_outputs...values.<name>` references
- Self-healing: the existing run trigger re-runs this workspace when Vault is redeployed, repopulating `TFC_VAULT_ADDR`, `TFC_VAULT_AUTH_PATH`, `TFC_VAULT_RUN_ROLE`, and `TFC_VAULT_ENCODED_CACERT`
- Empty-string fallback matches the repo's existing "won't drift" convention; sensitivity is unchanged