### PR TITLE
chore: Align scaffolding with terraform-root-module-template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,27 @@
 version: 2
 
-registries:
-  hcp-terraform:
-    type: terraform-registry
-    url: https://app.terraform.io
-    token: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+# Use this if you are referencing modules from a private module registry.
+# registries:
+#   hcp-terraform:
+#     type: terraform-registry
+#     url: https://app.terraform.io # Update this to a custom hostname if needed.
+#     token: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+#
+# If you add the private module registry configuration above, you must add
+# the `registries: '*'` configuration under the `terraform`
+# package-ecosystem configuration below.
 
 updates:
   - package-ecosystem: terraform
     directory: /
-    registries: '*'
     schedule:
       interval: weekly
+    commit-message:
+      prefix: chore(deps)
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: chore(ci)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,16 @@ jobs:
       - name: Lint YAML Files
         uses: craigsloggett/lint-yaml@747f85f46ec4711f7cb87e031f635e12e7310c98 # v1.0.21
 
+  shellcheck:
+    name: Shell
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Lint Shell Scripts
+        uses: craigsloggett/lint-shell@92d33c5528427fc13f2883aff90cb7439e3cb56d # v1.0.1
+
   terraform:
     name: Terraform
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@
 *.tfstate.*
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -14,7 +14,7 @@ rule "terraform_module_pinned_source" {
 # Checks that Terraform modules sourced from a registry specify a version.
 rule "terraform_module_version" {
   enabled = true
-  exact   = false
+  exact   = true
 }
 
 # Enforces naming conventions for resources, data sources, etc.
@@ -25,7 +25,7 @@ rule "terraform_naming_convention" {
 
 plugin "terraform" {
   enabled = true
-  version = "0.13.0"
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+  version = "0.14.1"
   preset  = "all"
 }

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,7 +1,6 @@
 extends: relaxed
 
-ignore-from-file:
-  - .gitignore
+ignore-from-file: .gitignore
 
 rules:
   comments:


### PR DESCRIPTION
- Dependabot → template form: `chore(deps)`/`chore(ci)` prefixes, private-registry config commented out
- Drops the lint-terraform private-registry credentials where present (no private registry in use)
- Activates CODEOWNERS (`* @craigsloggett`) where it was still the commented placeholder
- Adds a shellcheck job to the lint workflow
- `.yamllint.yml` and `.tflint.hcl` aligned to the template (indent-sequences, ignore-from-file, ruleset 0.14.1, `exact = true`)